### PR TITLE
Update create-db function

### DIFF
--- a/src/clojure_sqlite_example/core.clj
+++ b/src/clojure_sqlite_example/core.clj
@@ -17,10 +17,10 @@
 (defn create-db []
   (try (db-do-commands db
                        (create-table-ddl :news
-                                         [:date :text]
+                                         [[:date :text]
                                          [:url :text]
                                          [:title :text]
-                                         [:body :text]))
+                                         [:body :text]]))
        (catch Exception e (println e))))
 
 (create-db)


### PR DESCRIPTION
Update to reflect current `create-table-ddl` syntax